### PR TITLE
Fix the example of a simplified authentication code block

### DIFF
--- a/web/viikko2.md
+++ b/web/viikko2.md
@@ -1408,8 +1408,10 @@ Koska koodilohko saa saman arvon kuin if:n ehto, voidaan se yksinkertaistaa seur
 
 ```ruby
 def authenticate
-  username == "admin" and password == "secret"
-end   
+  authenticate_or_request_with_http_basic do |username, password|
+    username == "admin" and password == "secret"
+  end  
+end
 ```
 
 HTTP Basic -autentikaatio on kätevä tapa yksinkertaisiin sivujen suojaamistarpeisiin, mutta monimutkaisemmissa tilanteissa ja parempaa tietoturvaa edellytettäessä kannattaa käyttää muita ratkaisuja.


### PR DESCRIPTION
In the week 2 material, we implement a basic authentication, which (to my understanding) relies on retrieving `username` and `password` via HTTP using the `authenticate_or_request_with_http_basic`. However, after simplifying the boolean expression, the example in the material becomes:

```ruby
def authenticate
  username == "admin" and password == "secret"
end  
```
If the code above is meant to replace the `authenticate` method, I think it should still have the wrapping code block:
```ruby
def authenticate
  authenticate_or_request_with_http_basic do |username, password|
    username == "admin" and password == "secret"
  end  
end
```