### PR TITLE
Uniq has been removed in Rails 5.1, use distinct instead

### DIFF
--- a/web/viikko3.md
+++ b/web/viikko3.md
@@ -1123,7 +1123,7 @@ Olisi mahdollista myös määritellä, että oluen <code>raters</code> palauttai
 class Beer < ApplicationRecord
   #...
 
-  has_many :raters, -> { uniq }, through: :ratings, source: :user
+  has_many :raters, -> { distinct }, through: :ratings, source: :user
 
   #...
 end


### PR DESCRIPTION
Uniq was [deprecated](https://guides.rubyonrails.org/5_0_release_notes.html#active-record-deprecations) in 5.0 and [removed](https://github.com/rails/rails/commit/c6dcc37bee7e02066457cbbb4a7f3dbbc22159be) in 5.1. Week 3 material should use `distinct` instead.