### PR TITLE
Turku -> Espoo

### DIFF
--- a/web/viikko5.md
+++ b/web/viikko5.md
@@ -685,7 +685,7 @@ describe "BeermappingApi" do
 
     stub_request(:get, /.*espoo/).to_return(body: canned_answer, headers: { 'Content-Type' => "text/xml" })
 
-    places = BeermappingApi.places_in("turku")
+    places = BeermappingApi.places_in("espoo")
 
     expect(places.size).to eq(1)
     place = places.first


### PR DESCRIPTION
Fixed the typo in the Espoo example. 